### PR TITLE
Fix SettingHolder namespace and imports

### DIFF
--- a/src/Services/SettingHolder.php
+++ b/src/Services/SettingHolder.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace Juniyasyos\FilamentSettingsHub\Services\Services;
+namespace Juniyasyos\FilamentSettingsHub\Services;
 
-namespace Juniyasyos\FilamentSettingsHub\Facades\TomatoSettings;
-
-use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Collection;
+use Juniyasyos\FilamentSettingsHub\Facades\TomatoSettings;
 
 class SettingHolder
 {


### PR DESCRIPTION
## Summary
- fix namespace for SettingHolder service
- add collection and TomatoSettings imports

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6896d2d355f08329aac15637ca242cc6