### PR TITLE
refactor: extract settings hub view model

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,56 +1,17 @@
+@inject('viewModel', 'Juniyasyos\\FilamentSettingsHub\\ViewModels\\SettingsHubViewModel')
 <x-filament-panels::page>
-    @php
-        $settings = \Juniyasyos\FilamentSettingsHub\Facades\FilamentSettingsHub::load()
-            ->sortBy('order')
-            ->groupBy('group');
-        $tenant = \Filament\Facades\Filament::getTenant();
-    @endphp
-
-    @foreach ($settings as $settingGroup => $setting)
+    @foreach ($viewModel->settings as $settingGroup => $setting)
         <div class="fi-page">
-            {{-- <h1 class="fi-header filament-header-heading">
-                {{ str($settingGroup)->contains(['.', '::']) ? trans($settingGroup) : $settingGroup }}
-            </h1> --}}
-            
             <!-- Section: Anak langsung dari .fi-page agar mendapatkan gap-y-6 -->
             <section class="pt-6">
                 @foreach ($setting as $item)
-                    @php
-                        $canAccess = true;
-                        $routeUrl = $item->route
-                            ? ($tenant
-                                ? route($item->route, $tenant)
-                                : route($item->route))
-                            : null;
-                        $pageUrl = $item->page ? app($item->page)::getUrl() : null;
-
-                        if ($item->route && filament('filament-settings-hub')->isShieldAllowed()) {
-                            $page =
-                                optional(
-                                    \Illuminate\Support\Facades\Route::getRoutes()->getRoutesByName()[$item->route],
-                                )->action['controller'] ?? null;
-                            $page = $page ? str($page)->afterLast('\\') : null;
-                            $canAccess = $page
-                                ? \Filament\Facades\Filament::auth()
-                                    ->user()
-                                    ->can('page_' . $page)
-                                : false;
-                        } elseif ($item->page && filament('filament-settings-hub')->isShieldAllowed()) {
-                            $canAccess = \Filament\Facades\Filament::auth()
-                                ->user()
-                                ->can('page_' . str($item->page)->afterLast('\\'));
-                        }
-                    @endphp
-
-                    @if ($canAccess && ($routeUrl || $pageUrl))
+                    @if ($item->canAccess && ($item->routeUrl || $item->pageUrl))
                         <!-- Masing-masing item menggunakan .fi-section dan ditata dengan flex serta padding -->
-                        <a href="{{ $routeUrl ?? $pageUrl }}"
+                        <a href="{{ $item->routeUrl ?? $item->pageUrl }}"
                             class="fi-section flex p-4 mb-2 rounded-lg bg-white dark:fi-section-content hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-600">
                             <div class="p-2">
                                 @if (isset($item->icon))
-                                    <x-icon name="{{ $item->icon }}"
-                                        class="fi-icon-btn w-10 h-10 text-gray-800 dark:text-gray-200"
-                                        style="color: {{ $item->color ?? 'inherit' }}" />
+                                    <x-icon name="{{ $item->icon }}" class="fi-icon-btn w-10 h-10 text-gray-800 dark:text-gray-200" style="color: {{ $item->color ?? 'inherit' }}" />
                                 @else
                                     <x-heroicon-s-cog class="fi-icon-btn w-10 h-10 text-gray-800 dark:text-gray-200" />
                                 @endif

--- a/src/ViewModels/SettingsHubViewModel.php
+++ b/src/ViewModels/SettingsHubViewModel.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Juniyasyos\FilamentSettingsHub\ViewModels;
+
+use Filament\Facades\Filament;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Route;
+use Juniyasyos\FilamentSettingsHub\Facades\FilamentSettingsHub;
+
+class SettingsHubViewModel
+{
+    /**
+     * Processed settings grouped by their group name.
+     */
+    public Collection $settings;
+
+    public function __construct()
+    {
+        $this->settings = $this->buildSettings();
+    }
+
+    protected function buildSettings(): Collection
+    {
+        $settings = FilamentSettingsHub::load()
+            ->sortBy('order')
+            ->groupBy('group');
+
+        $tenant = Filament::getTenant();
+
+        return $settings->map(function (Collection $group) use ($tenant) {
+            return $group->map(function ($item) use ($tenant) {
+                $routeUrl = $item->route
+                    ? ($tenant ? route($item->route, $tenant) : route($item->route))
+                    : null;
+
+                $pageUrl = $item->page ? app($item->page)::getUrl() : null;
+
+                $canAccess = true;
+                if ($item->route && filament('filament-settings-hub')->isShieldAllowed()) {
+                    $page = optional(Route::getRoutes()->getRoutesByName()[$item->route] ?? null)->action['controller'] ?? null;
+                    $page = $page ? str($page)->afterLast('\\') : null;
+                    $canAccess = $page ? Filament::auth()->user()->can('page_' . $page) : false;
+                } elseif ($item->page && filament('filament-settings-hub')->isShieldAllowed()) {
+                    $canAccess = Filament::auth()->user()->can('page_' . str($item->page)->afterLast('\\'));
+                }
+
+                return (object) [
+                    'label' => $item->label,
+                    'description' => $item->description,
+                    'icon' => $item->icon,
+                    'color' => $item->color,
+                    'routeUrl' => $routeUrl,
+                    'pageUrl' => $pageUrl,
+                    'canAccess' => $canAccess,
+                ];
+            });
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- move settings, URL, and access computation into `SettingsHubViewModel`
- inject processed view model into `index` view and reduce Blade logic

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6896d2d67f088329be15e840613296f1