### PR TITLE
Improve dark theme styling and migration publish logic

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -8,7 +8,7 @@
 
     @foreach ($settings as $settingGroup => $setting)
         <div class="fi-page">
-            <h2 class="text-xl font-bold text-gray-900 dark:text-white">
+            <h2 class="text-xl font-bold">
                 {{ str($settingGroup)->contains(['.', '::']) ? trans($settingGroup) : $settingGroup }}
             </h2>
 
@@ -39,20 +39,20 @@
                     @endphp
 
                     @if ($canAccess && ($routeUrl || $pageUrl))
-                        <a href="{{ $routeUrl ?? $pageUrl }}" class="fi-section rounded-xl p-6 bg-white dark:fi-section-content ring-1 ring-gray-200 dark:ring-gray-700 transition hover:bg-gray-50 dark:hover:bg-gray-900">
+                        <a href="{{ $routeUrl ?? $pageUrl }}" class="fi-section">
                             <div class="flex items-start gap-4">
                                 <div class="p-2">
                                     @if (isset($item->icon))
-                                        <x-icon name="{{ $item->icon }}" class="w-10 h-10 text-gray-800 dark:text-gray-200" style="color: {{ $item->color ?? 'inherit' }}" />
+                                        <x-icon name="{{ $item->icon }}" class="w-10 h-10" style="color: {{ $item->color ?? 'inherit' }}" />
                                     @else
-                                        <x-heroicon-s-cog class="w-10 h-10 text-gray-800 dark:text-gray-200" />
+                                        <x-heroicon-s-cog class="w-10 h-10" />
                                     @endif
                                 </div>
                                 <div class="text-left">
-                                    <h3 class="text-lg font-bold text-gray-900 dark:text-white">
+                                    <h3 class="text-lg font-bold">
                                         {{ str($item->label)->contains(['.', '::']) ? trans($item->label) : $item->label }}
                                     </h3>
-                                    <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                    <p class="mt-1 text-sm">
                                         {{ str($item->description)->contains(['.', '::']) ? trans($item->description) : $item->description }}
                                     </p>
                                 </div>

--- a/src/Console/FilamentSettingsHubInstall.php
+++ b/src/Console/FilamentSettingsHubInstall.php
@@ -3,7 +3,6 @@
 namespace Juniyasyos\FilamentSettingsHub\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\File;
 use TomatoPHP\ConsoleHelpers\Traits\RunCommand;
 
 class FilamentSettingsHubInstall extends Command
@@ -38,13 +37,12 @@ class FilamentSettingsHubInstall extends Command
     public function handle()
     {
         $this->info('Publish Vendor Assets');
-        //Register migrations
-        if (! class_exists('SitesSettings')) {
-            $stubPath =  __DIR__ . '/../../database/migrations/sites_settings.php.stub';
-            $databasePath = database_path('migrations/' . date('Y_m_d_His', time()) . '_sites_settings.php');
 
-            File::copy($stubPath, $databasePath);
-        }
+        $this->call('vendor:publish', ['--tag' => 'filament-settings-hub-config']);
+        $this->call('vendor:publish', ['--tag' => 'filament-settings-hub-views']);
+        $this->call('vendor:publish', ['--tag' => 'filament-settings-hub-lang']);
+        $this->call('vendor:publish', ['--tag' => 'filament-settings-hub-migrations']);
+
         $this->callSilent('optimize:clear');
         $this->artisanCommand(["migrate"]);
         $this->artisanCommand(["optimize:clear"]);

--- a/src/FilamentSettingsHubServiceProvider.php
+++ b/src/FilamentSettingsHubServiceProvider.php
@@ -30,9 +30,12 @@ class FilamentSettingsHubServiceProvider extends ServiceProvider
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
         //Publish Migrations
-        $this->publishes([
-           __DIR__.'/../database/migrations' => database_path('migrations'),
-        ], 'filament-settings-hub-migrations');
+        if (! class_exists('SitesSettings')) {
+            $timestamp = date('Y_m_d_His', time());
+            $this->publishes([
+               __DIR__.'/../database/migrations/sites_settings.php.stub' => database_path('migrations/'.$timestamp.'_sites_settings.php'),
+            ], 'filament-settings-hub-migrations');
+        }
         //Register views
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'filament-settings-hub');
 


### PR DESCRIPTION
## Summary
- enhance settings hub page styling for dark mode
- publish migrations with timestamp and update install command to publish assets

## Testing
- `composer install`
- `composer test`
- `composer analyse` *(fails: Result is incomplete because of severe errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b7bfd6b44832990542e34a6c00254